### PR TITLE
ACTUALLY fix bug where campuses weren't displaying

### DIFF
--- a/college-management/src/components/Campuses.js
+++ b/college-management/src/components/Campuses.js
@@ -26,8 +26,9 @@ function Campuses() {
     const renderCampus = () => {
         console.log(campuses.length);
         console.log(campuses)
+        console.log(campuses.data)
 
-        if (campuses !== undefined) {
+        if (typeof campuses !== "string") {
             return <div className="campus-container">
                 {campuses.map(campus => (
                     <div key={campus.id}>


### PR DESCRIPTION
Checking campus didn't work because the length got set to the string
length for the error messages; checking campus.data didn't work because
it was always undefined (data coming from response.data).

What I wanted to check was if campus returned a string, so setting the
condition to typeof !== "string" works because normally it returns an
array. Yaaaaay /o/